### PR TITLE
添加CustomerServiceSecret到默认配置文件，不然会报错

### DIFF
--- a/chat/service/chat/api/etc/chat-api.yaml.bak
+++ b/chat/service/chat/api/etc/chat-api.yaml.bak
@@ -14,6 +14,7 @@ RedisCache:
 
 WeCom:                                              # 企业微信配置
   Port: 8887                                        # 企业微信回调监听端口（可选）默认为8887
+  CustomerServiceSecret: "xxxx-xxxx-xxxx"           # 企业微信客服消息 Secret
   CorpID: "wwxxxxxxxxxxxxxxxxxxxx"                  # 企业微信 CorpID
   Token: "xxxxxxxxxx"                               # 企业微信应用/客服消息 Token
   EncodingAESKey: "xxxxxxxxxxxxxxxx"                # 企业微信应用/客服消息 EncodingAESKey


### PR DESCRIPTION
chat/service/chat/api/etc/chat-api.yaml.bak 中缺少 CustomerServiceSecret，会导致报错，此为必选项，应该加入到配置文件中